### PR TITLE
Iterate over every chest item on each interaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>es.roobre</groupId>
     <artifactId>chestorganizer</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <build>
         <plugins>
             <plugin>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.14.3-R0.1-SNAPSHOT</version><!--change this value depending on the version or use LATEST-->
+            <version>1.14.4-R0.1-SNAPSHOT</version><!--change this value depending on the version or use LATEST-->
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/es/roobre/chestorganizer/ChestOrganizer.java
+++ b/src/main/java/es/roobre/chestorganizer/ChestOrganizer.java
@@ -18,7 +18,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Semaphore;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -33,8 +32,6 @@ public final class ChestOrganizer extends JavaPlugin implements Listener {
 
     private static final Set<Material> ACTIVATOR_MATERIALS = Stream.of(Material.REDSTONE_BLOCK).collect(Collectors.toSet());
     private static final Set<Material> ACTIVATOR_CONTAINERS = Stream.of(Material.CHEST).collect(Collectors.toSet());
-
-    private Semaphore mutex = new Semaphore(1);
 
     @Override
     public void onEnable() {

--- a/src/main/java/es/roobre/chestorganizer/NoReceiverException.java
+++ b/src/main/java/es/roobre/chestorganizer/NoReceiverException.java
@@ -1,4 +1,0 @@
-package es.roobre.chestorganizer;
-
-public class NoReceiverException extends RuntimeException {
-}

--- a/src/main/java/es/roobre/chestorganizer/Util.java
+++ b/src/main/java/es/roobre/chestorganizer/Util.java
@@ -39,4 +39,8 @@ public class Util {
 
         return amount;
     }
+
+    protected static int removeItems(Inventory src, ItemStack items) {
+        return removeItems(src, items.getType(), items.getAmount());
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,3 +1,3 @@
 name: ChestOrganizer
 main: es.roobre.chestorganizer.ChestOrganizer
-version: "1.0.1"
+version: "1.1.0"


### PR DESCRIPTION
This simplifies the logic of the plugin, and also enables more intuitive behavior. If an item could not be moved when first put, putting a different one will cause a retry, which can now move that item.

This also allows using dragEvents, since the stack in hand is never used as a reference.